### PR TITLE
Specify the minimum provider compatiblity

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">= 0.14.0"
+
+  required_providers {
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = ">= 2.5.0"
+    }
+    vault = {
+      source  = "hashicorp/vault"
+      version = ">= 3.0"
+    }
+  }
+}
+


### PR DESCRIPTION
The mail_enabled and security_enabled flags were added in v2.5.0 of the azuread
provider. I didn't make any effort to identify a specific minmimum vault version.